### PR TITLE
Use Dependabot to update GHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,10 @@ updates:
   allow:
   - dependency-type: direct
   - dependency-type: indirect
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "07:00"
+    timezone: Asia/Tokyo
+  open-pull-requests-limit: 99


### PR DESCRIPTION
## Description
Currently, GHA is not being updated.
We will use Dependabot to perform weekly updates.