### PR TITLE
Add `RUBYOPT=-w` when execute rake task

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -14,7 +14,9 @@ jobs:
       with:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: update jpostcode data
-      run: RUBYOPT=-w bundle exec rake jpostcode:data:update_all
+      run: bundle exec rake jpostcode:data:update_all
+      env:
+        RUBYOPT: "-w" 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: update jpostcode data
-      run: bundle exec rake jpostcode:data:update_all
+      run: RUBYOPT=-w bundle exec rake jpostcode:data:update_all
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:


### PR DESCRIPTION
sqlite3のメジャーバージョンアップで動かなくなる実装を使っていたのですが、長らく非推奨警告が出ていたようです
しかし、今は警告を出すようにしていなかったので気付いていませんでした（Actionsのログを見る必要があるんですが…）

悪いことは無いのでrake task実行時に警告を出すようにします。

ref: #242 