### PR TITLE
Bump sqlite3 from 1.7.3 to 2.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     racc (1.7.3)
     rake (13.2.1)
     rubyzip (2.3.2)
-    sqlite3 (2.0.0)
+    sqlite3 (2.0.1)
       mini_portile2 (~> 2.8.0)
 
 PLATFORMS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     racc (1.7.3)
     rake (13.2.1)
     rubyzip (2.3.2)
-    sqlite3 (1.7.3)
+    sqlite3 (2.0.0)
       mini_portile2 (~> 2.8.0)
 
 PLATFORMS

--- a/lib/base.rb
+++ b/lib/base.rb
@@ -81,13 +81,15 @@ module Jpostcode
       def insert(hash)
         db.execute(
           INSERT_SQL,
-          hash[:postcode],
-          hash[:prefecture], hash[:prefecture_kana], hash[:prefecture_code],
-          hash[:city], hash[:city_kana],
-          hash[:town], hash[:town_kana],
-          hash[:street],
-          hash[:office_name],
-          hash[:office_name_kana]
+          [
+            hash[:postcode],
+            hash[:prefecture], hash[:prefecture_kana], hash[:prefecture_code],
+            hash[:city], hash[:city_kana],
+            hash[:town], hash[:town_kana],
+            hash[:street],
+            hash[:office_name],
+            hash[:office_name_kana]
+          ]
         )
       end
     end

--- a/lib/office.rb
+++ b/lib/office.rb
@@ -60,11 +60,11 @@ module Jpostcode
             CSV.parse(a.get_input_stream.read) do |row|
               h = to_hash(row)
 
-              prefecture_kana, prefecture_code, city_kana, town_kana = db.execute(SELECT_SQL, h[:prefecture], h[:city], h[:town]).first
+              prefecture_kana, prefecture_code, city_kana, town_kana = db.execute(SELECT_SQL, [h[:prefecture], h[:city], h[:town]]).first
               if prefecture_code.nil?
-                prefecture_kana, prefecture_code, city_kana, town_kana = db.execute(SELECT_SQL, h[:prefecture], h[:city], convert_to_zen(convert_kansuji(h[:town]))).first
+                prefecture_kana, prefecture_code, city_kana, town_kana = db.execute(SELECT_SQL, [h[:prefecture], h[:city], convert_to_zen(convert_kansuji(h[:town]))]).first
                 if prefecture_code.nil?
-                  prefecture_kana, prefecture_code, city_kana = db.execute(EASY_SELECT_SQL, h[:prefecture], h[:city]).first
+                  prefecture_kana, prefecture_code, city_kana = db.execute(EASY_SELECT_SQL, [h[:prefecture], h[:city]]).first
                 end
               end
 


### PR DESCRIPTION
以下の非互換に対応しました。

> Removed support for non-Array bind parameters to methods Database#execute, #execute_batch, and #query, which has been deprecated since v1.3.0. [#511] @flavorjones

`data/json` にファイルが生成されるところまでは確認済みです。

差分: https://github.com/sparklemotion/sqlite3-ruby/compare/v1.7.3...v2.0.1
ref: #242