### PR TITLE
fix Jpostcode::Data::Office::ZIP_URL

### DIFF
--- a/lib/office.rb
+++ b/lib/office.rb
@@ -11,7 +11,7 @@ module Jpostcode
 
       private
 
-      ZIP_URL = 'https://www.post.japanpost.jp/zipcode/dl/jigyosyo/zip/jigyosyo.zip'.freeze
+      ZIP_URL = 'https://www.post.japanpost.jp/service/search/zipcode/download/office/zip/jigyosyo.zip'.freeze
 
       SELECT_SQL = <<-SQL
         SELECT


### PR DESCRIPTION
## Description
GitHub Actions (auto-update) execution failed.
https://github.com/kufu/jpostcode-data/actions/runs/26730012919/job/81592506326

The error indicates that the URL was Not Found.
```
Reset temp DB...
Retrieveing general zip data...
Retrieveing office zip data...
rake aborted!
OpenURI::HTTPError: 404 Not Found (OpenURI::HTTPError)
/home/runner/work/jpostcode-data/jpostcode-data/lib/office.rb:58:in 'Jpostcode::Data::Office#retrieve'
/home/runner/work/jpostcode-data/jpostcode-data/lib/base.rb:45:in 'Jpostcode::Data::Base#retrieve_and_save'
/home/runner/work/jpostcode-data/jpostcode-data/Rakefile:18:in 'block (3 levels) in <top (required)>'
/home/runner/work/jpostcode-data/jpostcode-data/vendor/bundle/ruby/3.4.0/gems/rake-13.3.1/exe/rake:27:in '<top (required)>'
/opt/hostedtoolcache/Ruby/3.4.5/x64/bin/bundle:25:in 'Kernel#load'
/opt/hostedtoolcache/Ruby/3.4.5/x64/bin/bundle:25:in '<main>'
Tasks: TOP => jpostcode:data:update_all
```

## Changes
Replace the download URL with a valid one.

## Reference
* https://www.post.japanpost.jp/service/search/zipcode/download/office/index-zip.html
